### PR TITLE
Release v1.3.3

### DIFF
--- a/meta/documents/changelog_de.md
+++ b/meta/documents/changelog_de.md
@@ -1,5 +1,10 @@
 # Release Notes für Elastic Export Rakuten.de
 
+## 1.3.1 (2018-01-09)
+
+### Behoben
+- An issue was fixed which caused the attribute value names to be wrong displayed because of the preset delimiter.
+
 ## v1.3.0 (2017-12-28)
 
 ### Hinzugefügt

--- a/meta/documents/changelog_de.md
+++ b/meta/documents/changelog_de.md
@@ -3,7 +3,7 @@
 ## 1.3.3 (2018-01-19)
 
 ### Behoben
-- Ein Fehler wurde behoben, bei dem Attributswerte mit dem Trennzeichen **|** im Namen Fehler bei Rakuten verursachten.
+- Ein Fehler wurde behoben, bei dem Attributswerte mit dem Trennzeichen **"|"** im Namen Fehler bei Rakuten verursachten.
 
 ## v1.3.2 (2017-01-11)
 

--- a/meta/documents/changelog_de.md
+++ b/meta/documents/changelog_de.md
@@ -3,7 +3,7 @@
 ## 1.3.3 (2018-01-19)
 
 ### Behoben
-- An issue was fixed which caused the attribute value names to be wrong displayed because of the preset delimiter.
+- Ein Fehler wurde behoben, bei dem Attributswerte mit dem Trennzeichen **|** im Namen Fehler bei Rakuten verursachten.
 
 ## v1.3.2 (2017-01-11)
 

--- a/meta/documents/changelog_en.md
+++ b/meta/documents/changelog_en.md
@@ -1,5 +1,10 @@
 # Release Notes for Elastic Export Rakuten.de
 
+## 1.3.1 (2018-01-09)
+
+### Fixed
+- An issue was fixed which caused the attribute value names to be wrong displayed because of the preset delimiter.
+
 ## v1.3.0 (2017-12-28)
 
 ### Added

--- a/meta/documents/changelog_en.md
+++ b/meta/documents/changelog_en.md
@@ -3,7 +3,7 @@
 ## 1.3.3 (2018-01-19)
 
 ### Fixed
-- An issue was fixed which caused the attribute value names to be wrong displayed because of the preset delimiter.
+- An issue was fixed which caused the attribute values which contained the delimeter **"|"** to cause an error on Rakuten. 
 
 ## v1.3.2 (2017-01-11)
 

--- a/plugin.json
+++ b/plugin.json
@@ -3,7 +3,7 @@
   "namespace": "ElasticExportRakutenDE",
   "type": "export",
   "serviceProvider": "ElasticExportRakutenDE\\ElasticExportRakutenDEServiceProvider",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "GNU AFFERO GENERAL PUBLIC LICENSE Version 3, 19 November 2007",
   "pluginIcon": "icon_plugin_md.png",
   "price": 0.00,

--- a/src/Generator/RakutenDE.php
+++ b/src/Generator/RakutenDE.php
@@ -457,7 +457,7 @@ class RakutenDE extends CSVPluginGenerator
                  * gets the attribute value name of each attribute value which is linked with the variation in a specific order,
                  * which depends on the $attributeNameCombination
                  */
-                $attributeValue = $this->elasticExportHelper->getAttributeValueSetShortFrontendName($variation, $settings, '|', $this->attributeNameCombination[$variation['data']['item']['id']]);
+                $attributeValue = $this->elasticExportHelper->getAttributeValueSetShortFrontendName($variation, $settings, '|', $this->attributeNameCombination[$variation['data']['item']['id']], '/');
 
 
                 if(!is_null($potentialParent) && strlen($attributeValue))


### PR DESCRIPTION
@plentymarkets/team-multichannel-koboldmaki 

Branch name was defined before. Another version were released in the meantime. Current branch name and version should be v1.3.3.

This is a fix for the case that in the AttributeValueName we would find the |(PIPE) delimiter, which causes problems for a client making Rakuten interpret the AttributeValueName as having multiple values.

To be merged after [v1.3.4 of ElasticExport](https://github.com/plentymarkets/plenty-plugin-elastic-export/pull/182)