### PR TITLE
Add all VAT classes supported by Rakuten

### DIFF
--- a/meta/documents/changelog_de.md
+++ b/meta/documents/changelog_de.md
@@ -3,7 +3,7 @@
 ## v1.3.31 (2020-02-03)
 
 ### Geändert
-- Alle von Rakuten unterstützen Mehrwertsteuerklassen werden jetzt mit der richtigen ID exportiert. Korrekt unterstützt werden jetzt auch Mehrwertsteuersätze von 10% / 20% / 13% / 2,1% / 5% / 5,5%
+- Alle von Rakuten unterstützten Mehrwertsteuerklassen werden jetzt mit der richtigen ID exportiert. Korrekt unterstützt werden jetzt auch Mehrwertsteuersätze von 10% / 20% / 13% / 2,1% / 5% / 5,5%.
 
 ## v1.3.30 (2019-11-28)
 

--- a/meta/documents/changelog_de.md
+++ b/meta/documents/changelog_de.md
@@ -1,5 +1,10 @@
 # Release Notes für Elastic Export Rakuten.de
 
+## v1.3.31 (2020-02-03)
+
+### Geändert
+- Alle von Rakuten unterstützen Mehrwertsteuerklassen werden jetzt mit der richtigen ID exportiert. Korrekt unterstützt werden jetzt auch Mehrwertsteuersätze von 10% / 20% / 13% / 2,1% / 5% / 5,5%
+
 ## v1.3.30 (2019-11-28)
 
 ### Behoben

--- a/meta/documents/changelog_de.md
+++ b/meta/documents/changelog_de.md
@@ -1,6 +1,6 @@
 # Release Notes für Elastic Export Rakuten.de
 
-## v1.3.31 (2020-02-03)
+## v1.3.31 (2020-02-06)
 
 ### Geändert
 - Alle von Rakuten unterstützten Mehrwertsteuerklassen werden jetzt mit der richtigen ID exportiert. Korrekt unterstützt werden jetzt auch Mehrwertsteuersätze von 10% / 20% / 13% / 2,1% / 5% / 5,5%.

--- a/meta/documents/changelog_en.md
+++ b/meta/documents/changelog_en.md
@@ -3,7 +3,7 @@
 ## v1.3.31 (2020-02-03)
 
 ### Changed
-- All VAT classes supported by Rakuten are now exported with the correct ID. Now the VAT classes for 10% / 20% / 13% / 2,1% / 5% / 5,5% are supported too.
+- All VAT classes supported by Rakuten are now exported with the correct IDs. Now the VAT classes for 10% / 20% / 13% / 2,1% / 5% / 5,5% are supported too.
 
 ## v1.3.30 (2019-11-28)
 

--- a/meta/documents/changelog_en.md
+++ b/meta/documents/changelog_en.md
@@ -1,6 +1,6 @@
 # Release Notes for Elastic Export Rakuten.de
 
-## v1.3.31 (2020-02-03)
+## v1.3.31 (2020-02-06)
 
 ### Changed
 - All VAT classes supported by Rakuten are now exported with the correct IDs. Now the VAT classes for 10% / 20% / 13% / 2,1% / 5% / 5,5% are supported too.

--- a/meta/documents/changelog_en.md
+++ b/meta/documents/changelog_en.md
@@ -1,5 +1,10 @@
 # Release Notes for Elastic Export Rakuten.de
 
+## v1.3.31 (2020-02-03)
+
+### Changed
+- All VAT classes supported by Rakuten are now exported with the correct ID. Now the VAT classes for 10% / 20% / 13% / 2,1% / 5% / 5,5% are supported too.
+
 ## v1.3.30 (2019-11-28)
 
 ### Fixed

--- a/plugin.json
+++ b/plugin.json
@@ -3,7 +3,7 @@
   "namespace": "ElasticExportRakutenDE",
   "type": "export",
   "serviceProvider": "ElasticExportRakutenDE\\ElasticExportRakutenDEServiceProvider",
-  "version": "1.3.30",
+  "version": "1.3.31",
   "license": "GNU AFFERO GENERAL PUBLIC LICENSE Version 3, 19 November 2007",
   "pluginIcon": "icon_plugin_md.png",
   "price": 0.00,

--- a/src/Generator/RakutenDE.php
+++ b/src/Generator/RakutenDE.php
@@ -1076,7 +1076,7 @@ class RakutenDE extends CSVPluginGenerator
     }
 
     /**
-     * Get id for vat
+     * Get rakuten tax id for vat value
      * @param string $vatValue
      * @return int
      */
@@ -1089,7 +1089,20 @@ class RakutenDE extends CSVPluginGenerator
                 return 2;
             case '0.00':
                 return 3;
+            case '10.00':
+                return 10;
+            case '20.00':
+                return 12;
+            case '13.00':
+                return 13;
+            case '2.10':
+                return 14;
+            case '5.00':
+                return 14;
+            case '5.50':
+                return 16;
             default:
+		// 19%
                 return 1;
         }
     }


### PR DESCRIPTION
This PR adds support for all VAT classes that can be used on Rakuten.

The VAT value <-> Rakuten ID matching from the [Rakuten WS docs](https://webservice.rakuten.de/documentation/method/add_product) was used